### PR TITLE
Expose analytics functions for testing and add error-handling tests

### DIFF
--- a/node_modules/axios/index.js
+++ b/node_modules/axios/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  get: async () => { throw new Error('axios.get not implemented'); },
+  post: async () => { throw new Error('axios.post not implemented'); }
+};

--- a/node_modules/nodemailer/index.js
+++ b/node_modules/nodemailer/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  createTransport: () => ({
+    sendMail: async () => {}
+  })
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "daily-analytics-report",
+  "version": "1.0.0",
+  "description": "",
+  "main": "report.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/report.js
+++ b/report.js
@@ -153,4 +153,8 @@ async function main() {
   console.log('✅ Report sent successfully!');
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(console.error);
+}
+
+module.exports = { getMailchimpData, getPostHogData, sendReport, main };

--- a/report.test.js
+++ b/report.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const axios = require('axios');
+const { getMailchimpData, getPostHogData } = require('./report');
+
+test('getMailchimpData returns zero metrics on error', async () => {
+  const originalGet = axios.get;
+  axios.get = async () => { throw new Error('failure'); };
+  const result = await getMailchimpData();
+  assert.deepStrictEqual(result, {
+    campaigns: 0,
+    emailsSent: 0,
+    openRate: 0,
+    clickRate: 0,
+    error: 'failure'
+  });
+  axios.get = originalGet;
+});
+
+test('getPostHogData returns zero metrics on error', async () => {
+  const originalPost = axios.post;
+  axios.post = async () => { throw new Error('oops'); };
+  const result = await getPostHogData();
+  assert.deepStrictEqual(result, {
+    pageViews: 0,
+    sessions: 0,
+    newUsers: 0,
+    error: 'oops'
+  });
+  axios.post = originalPost;
+});


### PR DESCRIPTION
## Summary
- export analytics helpers and gate main script execution
- add Node test runner configuration and basic error handling tests
- include minimal axios and nodemailer stubs for offline testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933507e7ec832a8c397dbd316d29f9